### PR TITLE
Enable datetime-based querying to Data Records collection

### DIFF
--- a/deploy/default/woudc-api-config.yml
+++ b/deploy/default/woudc-api-config.yml
@@ -254,13 +254,14 @@ resources:
                 bbox:  [-180, -90, 180, 90]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
             temporal:
-                begin: 1928-08-18
+                begin: 1928-08-18T00:00:00Z
                 end: null # or empty
         providers:
             - type: feature
               name: Elasticsearch
               data: ${WOUDC_API_ES_URL}/woudc_data_registry.uv_index_hourly
               id_field: identifier
+              time_field: observation_date
     totalozone:
         type: collection
         title: WOUDC Total Ozone

--- a/deploy/default/woudc-api-config.yml
+++ b/deploy/default/woudc-api-config.yml
@@ -187,6 +187,7 @@ resources:
               name: Elasticsearch
               data: ${WOUDC_API_ES_URL}/woudc_data_registry.deployment
               id_field: identifier
+              time_field: timestamp_date
     data_records:
         type: collection
         title: WOUDC Data Registry Data Records
@@ -198,7 +199,7 @@ resources:
                 bbox: [-180, -90, 180, 90]
                 crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
             temporal:
-                begin: 1928-08-18
+                begin: 1928-08-18T00:00:00Z
                 end: null # or empty
         providers:
             - type: feature

--- a/deploy/default/woudc-api-config.yml
+++ b/deploy/default/woudc-api-config.yml
@@ -187,7 +187,7 @@ resources:
               name: Elasticsearch
               data: ${WOUDC_API_ES_URL}/woudc_data_registry.deployment
               id_field: identifier
-              time_field: timestamp_date
+              time_field: timestamp_utc
     data_records:
         type: collection
         title: WOUDC Data Registry Data Records
@@ -261,7 +261,7 @@ resources:
               name: Elasticsearch
               data: ${WOUDC_API_ES_URL}/woudc_data_registry.uv_index_hourly
               id_field: identifier
-              time_field: observation_date
+              time_field: timestamp_utc
     totalozone:
         type: collection
         title: WOUDC Total Ozone


### PR DESCRIPTION
Add time_field as timestamp_date. Changed Data Records temporal start from type datetime.date to datetime.datetime to make compatible with pygeoapi api.py.

Enables queries of type: https://gods-geo.woudc-dev.cmc.ec.gc.ca/woudc-api/nightly/latest/oapi/collections/data_records/items?datetime=2010-01-01T00:00:00Z/2010-02-01T00:00:00Z