### PR TITLE
Peer Data Records Explore Fix

### DIFF
--- a/woudc_api/plugins/explore.py
+++ b/woudc_api/plugins/explore.py
@@ -246,7 +246,7 @@ class SearchPageProcessor(BaseProcessor):
                         'properties.station_id'
                     ],
                     'return': [
-                        'properties.name',
+                        'properties.station_name',
                         'properties.station_id',
                         'geometry'
                     ]


### PR DESCRIPTION
Change return field from `name` to `station_name` to match the data registry.