### PR TITLE
Allow toggle of verify_certs=False in ES connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,13 +52,13 @@ RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//mirror:\/\/mirrors.ubuntu.co
     # Install pygeoapi
     git clone ${PYGEOAPI_GITREPO} -b 0.19.0 --depth=1 && \
     cd pygeoapi && \
-    pip3 install -r requirements.txt && \
-    pip3 install . && \
+    pip install -r requirements.txt && \
+    pip install . && \
     cd ${BASEDIR} && \
     # Install woudc-extcsv
     git clone ${WOUDC_EXTCSV_GITREPO} -b master --depth=1 && \
     cd woudc-extcsv && \
-    pip3 install . && \
+    pip install . && \
     cd ${BASEDIR}
 
 # Copy application code
@@ -66,9 +66,9 @@ COPY . ${APPDIR}
 
 # Install application dependencies
 RUN cd ${APPDIR} && \
-    pip3 install -r requirements.txt && \
-    pip3 install gunicorn gevent Flask-Cors && \
-    pip3 install .
+    pip install -r requirements.txt && \
+    pip install gunicorn gevent Flask-Cors && \
+    pip install .
 
 # Cleanup unnecessary packages and files
 RUN apt-get remove --purge -y git && \

--- a/README.md
+++ b/README.md
@@ -35,23 +35,23 @@ source bin/activate
 mkdir schemas.opengis.net
 curl -O http://schemas.opengis.net/SCHEMAS_OPENGIS_NET.zip && unzip ./SCHEMAS_OPENGIS_NET.zip "ogcapi/*" -d schemas.opengis.net && rm -f ./SCHEMAS_OPENGIS_NET.zip
 
-# optional for development: clone pygeoapi codebase and install
+# clone pygeoapi codebase and install
 git clone https://github.com/geopython/pygeoapi.git
 cd pygeoapi
-pip3 install -r requirements.txt
-python3 setup.py install
+pip install -r requirements.txt
+pip install .
 cd ..
 
 # clone woudc-extcsv and install
 git clone https://github.com/woudc/woudc-extcsv.git
 cd woudc-extcsv
-python3 setup.py install
+pip install .
 cd ..
 
 # clone woudc-api codebase and install
 git clone https://github.com/woudc/woudc-api.git
 cd woudc-api
-python3 setup.py install
+pip install .
 
 # set system environment variables
 cp default.env local.env

--- a/default.env
+++ b/default.env
@@ -5,6 +5,8 @@ export WOUDC_API_ES_USERNAME=elasticsearch
 export WOUDC_API_ES_PASSWORD=<secret>
 export WOUDC_API_ES_URL=http://${WOUDC_API_ES_USERNAME}:${WOUDC_API_ES_PASSWORD}@localhost:9200
 export WOUDC_API_ES_INDEX_PREFIX=woudc_data_registry
+# optional: defaults to true if not set. Set to false for DEV testing
+# export WOUDC_API_VERIFY_CERTS=true
 export WOUDC_API_OGC_SCHEMAS_LOCATION=/opt/woudc-api/schemas.opengis.net
 export PYGEOAPI_CONFIG=/path/to/woudc-api-config.yml
 export PYGEOAPI_OPENAPI=/path/to/woudc-api-openapi.yml

--- a/deploy/default/woudc-api-config.yml
+++ b/deploy/default/woudc-api-config.yml
@@ -78,7 +78,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.project
               id_field: identifier
     discovery_metadata:
@@ -96,7 +96,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.discovery_metadata
               id_field: identifier
     datasets:
@@ -114,7 +114,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.dataset
               id_field: identifier
     countries:
@@ -132,7 +132,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.country
               id_field: identifier
     contributors:
@@ -150,7 +150,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.contributor
               id_field: identifier
     stations:
@@ -168,7 +168,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.station
               id_field: woudc_id
     instruments:
@@ -186,7 +186,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.instrument
               id_field: identifier
     deployments:
@@ -204,7 +204,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.deployment
               id_field: identifier
     data_records:
@@ -222,7 +222,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.data_record
               id_field: identifier
               time_field: timestamp_utc
@@ -241,7 +241,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.notification
               id_field: published_date
               date_field: published_date
@@ -260,7 +260,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.peer_data_record
               id_field: identifier
               time_field: start_datetime
@@ -279,7 +279,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.uv_index_hourly
               id_field: identifier
               time_field: timestamp_utc
@@ -298,7 +298,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.totalozone
               id_field: identifier
               time_field: observation_date
@@ -317,7 +317,7 @@ resources:
                 end: null # or empty
         providers:
             - type: feature
-              name: woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
+              name:  woudc_api.provider.elasticsearch.ElasticsearchWOUDCProvider
               data: ${WOUDC_API_ES_URL}/${WOUDC_API_ES_INDEX_PREFIX}.ozonesonde
               id_field: identifier
               time_field: timestamp_date

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       WOUDC_API_OGC_SCHEMAS_LOCATION: /data/web/woudc-api-nightly/schemas.opengis.net
       PYGEOAPI_CONFIG: /data/web/woudc-api-nightly/woudc-api/deploy/default/woudc-api-config.yml
       PYGEOAPI_OPENAPI: /data/web/woudc-api-nightly/woudc-api/deploy/default/woudc-api-openapi.yml
-      # env variables from here are sourced your local.env
+      # env variables from here are sourced from your docker.env
       WOUDC_API_BIND_HOST: ${WOUDC_API_BIND_HOST}
       WOUDC_API_BIND_PORT: ${WOUDC_API_BIND_PORT}
       WOUDC_API_URL: ${WOUDC_API_URL}
@@ -50,6 +50,7 @@ services:
       WOUDC_API_ES_PASSWORD: ${WOUDC_API_ES_PASSWORD}
       WOUDC_API_ES_URL: ${WOUDC_API_ES_URL}
       WOUDC_API_ES_INDEX_PREFIX: ${WOUDC_API_ES_INDEX_PREFIX}
+      WOUDC_API_VERIFY_CERTS: ${WOUDC_API_VERIFY_CERTS}
     ports:
       - "${WOUDC_API_BIND_PORT}:${WOUDC_API_BIND_PORT}"
 

--- a/woudc_api/app.py
+++ b/woudc_api/app.py
@@ -77,8 +77,8 @@ def serve(ctx):
     :returns: void
     """
 
-    HOST = os.environ.get('WOUDC_API_BIND_HOST', '0.0.0.0')
-    PORT = os.environ.get('WOUDC_API_BIND_PORT', 5000)
+    HOST = os.getenv('WOUDC_API_BIND_HOST', '0.0.0.0')
+    PORT = os.getenv('WOUDC_API_BIND_PORT', 5000)
 
     app.run(debug=True, host=HOST, port=PORT)
 

--- a/woudc_api/plugins/distinct.py
+++ b/woudc_api/plugins/distinct.py
@@ -47,7 +47,7 @@ import os
 import logging
 
 from elasticsearch import Elasticsearch
-from urllib.parse import urlparse
+from elastic_transport import TlsError
 
 from pygeoapi.process.base import BaseProcessor, ProcessorExecuteError
 
@@ -282,40 +282,49 @@ class GroupSearchProcessor(BaseProcessor):
 
         # Extract URL information from
         LOGGER.debug('Setting Elasticsearch properties')
-        es_url = os.environ.get('WOUDC_API_ES_URL',
-                                'http://elastic:password@localhost:9200')
+        es_url = os.getenv('WOUDC_API_ES_URL',
+                           'http://elastic:password@localhost:9200')
+        self.verify_certs = os.getenv(
+                            'WOUDC_API_VERIFY_CERTS',
+                            'True').strip().lower() in ('true', '1', 'yes')
+        host = es_url.split('@', 1)[-1]
 
-        # Parse the URL to extract components
-        parsed_url = urlparse(es_url)
-        host = parsed_url.hostname
-        username = parsed_url.username
-        password = parsed_url.password
+        self.index_prefix = os.getenv('WOUDC_API_ES_INDEX_PREFIX',
+                                      'woudc_data_registry') + '.'
 
-        self.index_prefix = os.environ.get('WOUDC_API_ES_INDEX_PREFIX',
-                                           'woudc_data_registry') + '.'
+        LOGGER.debug(f"Host: {host}")
+        LOGGER.debug(f"Index prefix name: {self.index_prefix}")
 
-        LOGGER.debug('Host for distinct.py: {}'.format(host))
-        LOGGER.debug('Index prefix name: {}'.format(self.index_prefix))
-        LOGGER.debug('Username: {}'.format(username))
-
-        LOGGER.debug('Connecting to Elasticsearch')
-        auth = (username, password)
-        self.es = Elasticsearch(
-            [es_url],
-            http_auth=auth,
-            verify_certs=False
+        LOGGER.debug(
+            f"Connecting to Elasticsearch (verify_certs=${self.verify_certs})"
         )
+        try:
+            self.es = Elasticsearch(es_url, verify_certs=self.verify_certs)
+        except TlsError as err:
+            if self.verify_certs:
+                msg = (
+                    f"SSL certificate verification failed: {err}.\n"
+                    "Check your SSL certificates or set "
+                    "WOUDC_API_VERIFY_CERTS=False if "
+                    "connecting to an internal dev server."
+                )
+            else:
+                msg = f"Unexpected TLS error: {err}"
+
+            LOGGER.error(msg)
+            raise ProcessorExecuteError(msg)
 
         if not self.es.ping():
-            msg = f'Cannot connect to Elasticsearch: {host}'
+            msg = f"Cannot connect to Elasticsearch: {host}"
             LOGGER.error(msg)
             raise ProcessorExecuteError(msg)
 
         LOGGER.debug('Checking Elasticsearch version')
         version = float(self.es.info()['version']['number'][:3])
         if version < 8:
-            msg = 'Elasticsearch version below 8 not supported ({})' \
-                  .format(version)
+            msg = (
+                f"Elasticsearch version below 8 not supported ({version})"
+            )
             LOGGER.error(msg)
             raise ProcessorExecuteError(msg)
 

--- a/woudc_api/plugins/explore.py
+++ b/woudc_api/plugins/explore.py
@@ -47,7 +47,7 @@ import os
 import logging
 
 from elasticsearch import Elasticsearch
-from urllib.parse import urlparse
+from elastic_transport import TlsError
 
 from pygeoapi.process.base import BaseProcessor, ProcessorExecuteError
 
@@ -129,41 +129,52 @@ class SearchPageProcessor(BaseProcessor):
         BaseProcessor.__init__(self, provider_def, PROCESS_SETTINGS)
 
         LOGGER.debug('Setting Elasticsearch properties')
-        es_url = os.environ.get('WOUDC_API_ES_URL',
-                                'http://elastic:password@localhost:9200')
+        es_url = os.getenv('WOUDC_API_ES_URL',
+                           'http://elastic:password@localhost:9200')
+        self.verify_certs = os.getenv(
+                            'WOUDC_API_VERIFY_CERTS',
+                            'True').strip().lower() in ('true', '1', 'yes')
 
-        # Parse the URL to extract components
-        parsed_url = urlparse(es_url)
-        host = parsed_url.hostname
-        username = parsed_url.username
-        password = parsed_url.password
+        host = es_url.split('@', 1)[-1]
 
-        self.index_prefix = os.environ.get('WOUDC_API_ES_INDEX_PREFIX',
-                                           'woudc_data_registry') + '.'
+        self.index_prefix = os.getenv('WOUDC_API_ES_INDEX_PREFIX',
+                                      'woudc_data_registry') + '.'
         self.index = self.index_prefix + 'contribution'
 
-        LOGGER.debug('Host: {}'.format(host))
-        LOGGER.debug('Index prefix name: {}'.format(self.index_prefix))
-        LOGGER.debug('Index name: {}'.format(self.index))
+        LOGGER.debug(f"Host: {host}")
+        LOGGER.debug(f"Index prefix name: {self.index_prefix}")
+        LOGGER.debug(f"Index name: {self.index}")
 
-        LOGGER.debug('Connecting to Elasticsearch')
-        auth = (username, password)
-        self.es = Elasticsearch(
-            [es_url],
-            http_auth=auth,
-            verify_certs=False
+        LOGGER.debug(
+            f"Connecting to Elasticsearch (verify_certs=${self.verify_certs})"
         )
+        try:
+            self.es = Elasticsearch(es_url, verify_certs=self.verify_certs)
+        except TlsError as err:
+            if self.verify_certs:
+                msg = (
+                    f"SSL certificate verification failed: {err}.\n"
+                    "Check your SSL certificates or set "
+                    "WOUDC_API_VERIFY_CERTS=False if "
+                    "connecting to an internal test server."
+                )
+            else:
+                msg = f"Unexpected TLS error: {err}"
+
+            LOGGER.error(msg)
+            raise ProcessorExecuteError(msg)
 
         if not self.es.ping():
-            msg = f'Cannot connect to Elasticsearch: {host}'
+            msg = f"Cannot connect to Elasticsearch: {host}"
             LOGGER.error(msg)
             raise ProcessorExecuteError(msg)
 
         LOGGER.debug('Checking Elasticsearch version')
         version = float(self.es.info()['version']['number'][:3])
         if version < 8:
-            msg = 'Elasticsearch version below 8 not supported ({})' \
-                  .format(version)
+            msg = (
+                f"Elasticsearch version below 8 not supported ({version})"
+            )
             LOGGER.error(msg)
             raise ProcessorExecuteError(msg)
 

--- a/woudc_api/plugins/validate.py
+++ b/woudc_api/plugins/validate.py
@@ -47,7 +47,7 @@ import os
 import logging
 
 from elasticsearch import Elasticsearch
-from urllib.parse import urlparse
+from elastic_transport import TlsError
 
 from pygeoapi.process.base import BaseProcessor, ProcessorExecuteError
 from woudc_extcsv import (ExtendedCSV, MetadataValidationError,
@@ -127,39 +127,49 @@ class ExtendedCSVProcessor(BaseProcessor):
         BaseProcessor.__init__(self, provider_def, PROCESS_SETTINGS)
 
         LOGGER.debug('Setting Elasticsearch properties')
-        es_url = os.environ.get('WOUDC_API_ES_URL',
-                                'http://elastic:password@localhost:9200')
+        es_url = os.getenv('WOUDC_API_ES_URL',
+                           'http://elastic:password@localhost:9200')
+        self.verify_certs = os.getenv(
+                            'WOUDC_API_VERIFY_CERTS',
+                            'True').strip().lower() in ('true', '1', 'yes')
+        host = es_url.split('@', 1)[-1]
 
-        # Parse the URL to extract components
-        parsed_url = urlparse(es_url)
-        host = parsed_url.hostname
-        username = parsed_url.username
-        password = parsed_url.password
+        self.index_prefix = os.getenv('WOUDC_API_ES_INDEX_PREFIX',
+                                      'woudc_data_registry') + '.'
 
-        self.index_prefix = os.environ.get('WOUDC_API_ES_INDEX_PREFIX',
-                                           'woudc_data_registry') + '.'
+        LOGGER.debug(f"Host: {host}")
+        LOGGER.debug(f"Index prefix name: {self.index_prefix}")
 
-        LOGGER.debug('Host: {}'.format(host))
-        LOGGER.debug('Index prefix name: {}'.format(self.index_prefix))
-
-        LOGGER.debug('Connecting to Elasticsearch')
-        auth = (username, password)
-        self.es = Elasticsearch(
-            [es_url],
-            http_auth=auth,
-            verify_certs=False
+        LOGGER.debug(
+            f"Connecting to Elasticsearch (verify_certs=${self.verify_certs})"
         )
+        try:
+            self.es = Elasticsearch(es_url, verify_certs=self.verify_certs)
+        except TlsError as err:
+            if self.verify_certs:
+                msg = (
+                    f"SSL certificate verification failed: {err}.\n"
+                    "Check your SSL certificates or set "
+                    "WOUDC_API_VERIFY_CERTS=False if "
+                    "connecting to an internal dev server."
+                )
+            else:
+                msg = f"Unexpected TLS error: {err}"
+
+            LOGGER.error(msg)
+            raise ProcessorExecuteError(msg)
 
         if not self.es.ping():
-            msg = f'Cannot connect to Elasticsearch: {host}'
+            msg = f"Cannot connect to Elasticsearch: {host}"
             LOGGER.error(msg)
             raise ProcessorExecuteError(msg)
 
         LOGGER.debug('Checking Elasticsearch version')
         version = float(self.es.info()['version']['number'][:3])
         if version < 8:
-            msg = 'Elasticsearch version below 8 not supported ({})' \
-                  .format(version)
+            msg = (
+                f"Elasticsearch version below 8 not supported ({version})"
+            )
             LOGGER.error(msg)
             raise ProcessorExecuteError(msg)
 


### PR DESCRIPTION
Update ES connection to toggle verify_certs=False
- Update to use 'pip install .'  instead of 'python3 setup.py install'
- Update ES connection to handle TLS errors
- Update to use 'os.getenv()'