### PR TITLE
Adjusting woudc-api discovery metadata query

### DIFF
--- a/woudc_api/provider/elasticsearch.py
+++ b/woudc_api/provider/elasticsearch.py
@@ -36,6 +36,7 @@ from elastic_transport import TlsError
 from pygeoapi.provider.elasticsearch_ import ElasticsearchProvider
 from pygeoapi.provider.base import (ProviderConnectionError,
                                     ProviderQueryError)
+from flask import request
 
 LOGGER = logging.getLogger(__name__)
 
@@ -116,3 +117,59 @@ class ElasticsearchWOUDCProvider(ElasticsearchProvider):
         except exceptions.NotFoundError as err:
             LOGGER.error(err)
             raise ProviderQueryError(err)
+
+    def query(self, offset=0, limit=10, resulttype='results',
+              bbox=[], datetime_=None, properties=[], sortby=[],
+              select_properties=[], skip_geometry=False, q=None,
+              filterq=None, **kwargs):
+
+        language = request.args.get('lang', 'en')
+
+        new_features = []
+
+        records = super().query(
+            offset=offset, limit=100,
+            resulttype=resulttype, bbox=bbox,
+            datetime_=datetime_, properties=properties,
+            sortby=sortby,
+            select_properties=select_properties,
+            skip_geometry=skip_geometry,
+            q=q)
+
+        if self.index_name.split('.')[-1] == 'discovery_metadata':
+            LOGGER.debug('Intercepting default ES response')
+            for feature in records['features']:
+                if feature['id'].endswith(language):
+                    feature['id'] = feature['id'].rsplit(f"_{language}")[0]
+                    new_features.append(feature)
+            records['features'] = new_features
+
+        records['numberMatched'] = len(records['features']) + offset
+        records['numberReturned'] = len(records['features'])
+
+        return records
+
+    def get(self, identifier, **kwargs):
+        """
+        Get ES document by id
+
+        :param identifier: feature id
+
+        :returns: dict of single GeoJSON feature
+        """
+
+        language = request.args.get('lang', 'en')
+
+        LOGGER.info("Getting identifier: %s with language: %s",
+                    identifier, language)
+
+        if self.index_name.split('.')[-1] == 'discovery_metadata':
+            identifier2 = f'{identifier}_{language}'
+        else:
+            identifier2 = identifier
+
+        dataset = super().get(identifier2, **kwargs)
+
+        dataset['id'] = dataset['id'].rsplit(f"_{language}")[0]
+
+        return dataset


### PR DESCRIPTION
 - Allowing user to change the language with ?lang=[en|fr]
 - Only using the discovery metadata according to that language
 - Added the query and get method to ElasticsearchWOUDCProvider to override the parent methods